### PR TITLE
Added the ability to associate custom properties to the generated dom element object

### DIFF
--- a/Source/mooml-globalize.js
+++ b/Source/mooml-globalize.js
@@ -9,6 +9,7 @@ source: http://github.com/eneko/mooml
 
 authors:
 - Eneko Alonso (http://enekoalonso.com)
+- Ahmad Nassri (http://ahmadnassri.com)
 
 provides:
 - Window.div

--- a/Source/mooml.js
+++ b/Source/mooml.js
@@ -10,6 +10,7 @@ htmltags: http://www.w3schools.com/html5/html5_reference.asp
 
 authors:
 - Eneko Alonso: (http://enekoalonso.com)
+- Ahmad Nassri (http://ahmadnassri.com)
 
 credits:
 - Ed Spencer: Mooml is based on Ed Spencer's Jaml (http://edspencer.github.com/jaml)
@@ -32,7 +33,7 @@ requires:
 
 var Mooml = {
 
-    version: '1.2.4',
+    version: '1.3.1',
     templates: {},
     engine: { callstack: [], tags: {} },
 
@@ -81,17 +82,20 @@ var Mooml = {
 
         Array.from([data, {}].pick()).each(function(params, index) {
             if (bind) {
-            template.code.apply(bind, [params, index]);
+                template.code.apply(bind, [params, index]);
             } else {
                 template.code(params, index);
             }
+
             elements.append(template.nodes.filter(function(node) {
                 return node.getParent() === null;
             }));
+
             template.nodes.empty();
         });
 
         this.engine.callstack.pop();
+
         if (this.engine.callstack.length) {
             if (template.elementRefs) {
                 Array.extend(this.engine.callstack.getLast().elementRefs, template.elementRefs);
@@ -117,14 +121,15 @@ var Mooml = {
                 for (var i=0, l=arguments.length; i<l; i++) {
                     var argument = arguments[i];
                     if (typeOf(argument) === "function") argument = argument();
+
                     switch (typeOf(argument)) {
                         case "array":
                         case "element":
-                        case "collection": {
+                        case "collection":
                             el.adopt(argument);
                             break;
-                        }
-                        case "string": {
+
+                        case "string":
                             if (template) {
                                 el.getChildren().each(function(child) {
                                     template.nodes.erase(child);
@@ -132,28 +137,29 @@ var Mooml = {
                             }
                             el.set('html', el.get('html') + argument);
                             break;
-                        }
-                        case "number": {
+
+                        case "number":
                             el.appendText(argument.toString());
                             break;
-                        }
-                        case "object": {
+
+                        case "object":
                             if (i === 0) {
                                 if (template && template.elementRefs && argument.id) {
                                     template.elementRefs[argument.id] = el;
                                 }
+
                                 el.set(argument);
                             } else if (typeOf(argument.toElement) == "function") {
                                 el.adopt(argument.toElement());
-                            } else {
-                                Object.append(el, argument);
                             }
                             break;
-                        }
                     }
                 }
 
-                if (template) template.nodes.push(el);
+                if (template) {
+                    template.nodes.push(el);
+                }
+
                 return el;
             }
         });
@@ -173,6 +179,7 @@ var Mooml = {
         var codeStr = code.toString();
         var args = codeStr.match(/\(([a-zA-Z0-9,\s]*)\)/)[1].replace(/\s/g, '').split(',');
         var body = codeStr.match(/\{([\s\S]*)\}/m)[1];
+
         for (var i=this.htmlTags.length; --i >= 0; ) {
             body = body.replace(new RegExp('(^|[^\\w.])(' + this.htmlTags[i] + ')([\\s]*(?=\\())', 'g'), '$1Mooml.engine.tags.$2$3')
         }
@@ -191,6 +198,7 @@ Mooml.Template = new Class({
         if (options && options.elementRefs && typeof(options.elementRefs) === "object") {
             this.elementRefs = options.elementRefs;
         }
+
         this.name = name;
         this.code = code;
         this.prepared = false;
@@ -228,7 +236,6 @@ Mooml.Templates = new Class({
         var template = this.templates[name];
         return (template)? template.render(data, [bind, this].pick()) : null;
     }
-
 });
 
 


### PR DESCRIPTION
example:

``` javascript
div({'id': 'test'}, {'foo': 'bar'});
```

which you can retrieve later by accessing the object in JavaScript:

``` javascript
alert(document.getElementById('test').foo);
```
