### PR TITLE
Added ability to render multiple templates on same element

### DIFF
--- a/Source/mooml.js
+++ b/Source/mooml.js
@@ -223,6 +223,10 @@ Mooml.Templates = new Class({
      * @param {Object} bind Optional Changes the scope of "this" within the target template to refer to the bind parameter.
      */
     renderTemplate: function(name, data, bind) {
+        if (typeOf(name) === 'array')
+          return name.map(function(part) {
+            return this.renderTemplate(part, data, bind)
+          }.bind(this));
         var template = this.templates[name];
         return (template)? template.render(data, [bind, this].pick()) : null;
     }


### PR DESCRIPTION
Hi eneko,

Mooml looks really great, I enjoy it a lot. However, if I am rendering multiple nested templates, I have to do this (code is in coffeescript):

``` javascript
Mooml.register 'parent-template', (items) ->
  dl {}, items.map (item) ->
    [ Mooml.render(['partial1'], item), Mooml.render(['partial2'], item), ... ]
```

This is the case, when you have a very modular template structure and want to compose a view/template for one item of multiple partials. I added 4 lines of code and now you can do this:

``` javascript
Mooml.register 'parent-template', (items) ->
  dl {}, items.map (item) ->
    Mooml.render(['partial1', 'partial2', ...], item)
```

I hope you find it useful. Keep up the good work!

Best regards,
Martin
